### PR TITLE
escapeHTML had exchanged < and >.

### DIFF
--- a/src/thermos.coffee
+++ b/src/thermos.coffee
@@ -58,8 +58,8 @@ normalizeUrl = (root, url, ext) ->
 escapeHTML = (str) ->
   String(str)
   .replace(/&(?!\w+;|#\d+;|#x[\da-f]+;)/gi, '&amp;')
-  .replace(/</g, '&gt;')
-  .replace(/>/g, '&lt;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
   .replace(/"/g, '&quot;')
   .replace(/'/g, '&apos;')
   .replace(/—/g, '&mdash;')

--- a/test/templates.coffee
+++ b/test/templates.coffee
@@ -171,7 +171,7 @@ describe "html", ->
     render : ->
       @h1 ->
         @span '<b>—&</b>"\'&mdash;hi'
-    output : "<h1><span>&gt;b&lt;&mdash;&amp;&gt;/b&lt;&quot;&apos;&mdash;hi</span></h1>"
+    output : "<h1><span>&lt;b&gt;&mdash;&amp;&lt;/b&gt;&quot;&apos;&mdash;hi</span></h1>"
 
   it "gets left alone if the string is modified to be html safe", test
     render : ->


### PR DESCRIPTION
EscapeHTML had been exchanging < and >.  For example, if the text being escaped was '>1' it ended up being displayed in the browser as '<1'.
